### PR TITLE
Add revisionable string to generate.entity.content.yml

### DIFF
--- a/translations/generate.entity.content.yml
+++ b/translations/generate.entity.content.yml
@@ -16,3 +16,4 @@ questions:
     has-bundles: 'Do you want this (content) entity to have bundles'
     base-path: 'Enter the base-path for the content entity routes'
     is-translatable: 'Is your entity translatable'
+    revisionable: 'Is your entity revisionable'


### PR DESCRIPTION
When using drupal *generate:entity:content* command, the revisionable option has no label in English, instead, you see this *commands.generate.entity.content.questions.revisionable*
Proposing patch to include the human readable question.
Thanks