### PR TITLE
incorporate changes from main project readme

### DIFF
--- a/translations/application.yml
+++ b/translations/application.yml
@@ -32,6 +32,11 @@ messages:
     learning:
         route: "In order to to create pages it is necessary to define routes for them.\nA route maps a URL path to a controller. It defines what function\nor method will be called when a URL is accessed.\nIf the user accesses http://drupal8.dev/{{ route.path }}, the routing\nsystem will look for a route with that path. In this case it will find a\nmatch, and execute the _controller callback. In this case the callback is\ndefined as a classname\n(\"\\Drupal\\{{ module }}\\Controller\\{{ class_name }}\")\nand a method (\"{{ route.method }}\")."
     autocomplete: |
+                Bash: Bash support depends on the http://bash-completion.alioth.debian.org/
+                project which can be installed with your package manager of choice. Then add
+                this line to your shell configuration file.
+                <info>source "$HOME/.console/console.rc" 2>/dev/null</info>
+
                 Bash or Zsh: Add this line to your shell configuration file:
                 <info>source "$HOME/.console/console.rc" 2>/dev/null</info>
 


### PR DESCRIPTION
output of `drupal init` should include hint that an external dependency is required. copied text from March 2016 update of main project readme.md.