### PR TITLE
Fixed syntax found in error message

### DIFF
--- a/translations/chain.yml
+++ b/translations/chain.yml
@@ -13,8 +13,8 @@ messages:
     set-inline-placeholders: 'Pass inline placeholders as:'
     select-value-for-placeholder: 'Select value for "%s" placeholder'
     enter-value-for-placeholder: 'Enter value for "%s" placeholder'
-    legacy-inline: 'Update inline legacy placeholders from %{{name}} to {{ name }}.'
-    legacy-environment: 'Update environment legacy placeholders from ${{(NAME}} or %env(NAME)% to {{ env("NAME")}}.'
+    legacy-inline: 'Update inline legacy placeholders from %{{name}} to {{name}}.'
+    legacy-environment: 'Update environment legacy placeholders from ${{(NAME}} or %env(NAME)% to {{env("NAME")}}.'
     metadata-registration: |
       You should register your chain file as command by providing metadata, more info at:
          https://docs.drupalconsole.com/en/chains/registering.html


### PR DESCRIPTION
If I leave the spaces on the placeholder, DC gives an error, changed the message to show the valid syntax