### PR TITLE
Added translation file for Paragraph type export command

### DIFF
--- a/translations/config.export.paragraph.type.yml
+++ b/translations/config.export.paragraph.type.yml
@@ -1,0 +1,23 @@
+description: 'Export a specific paragraph type and their fields.'
+arguments:
+    paragraph-type: 'Paragraph Type to be exported'
+questions:
+    paragraph-type: 'Paragraph Type to be exported'
+    optional-config: 'Export paragraph type in module as an optional configuration'
+messages:
+    paragraph-type-exported: 'Exporting paragraph type'
+options:
+    optional-config: 'Export paragraph type as an optional YAML configuration in your module'
+    remove-uuid: 'If set, the configuration will be exported without uuid key.'
+    remove-config-hash: 'If set, the configuration will be exported without the default site hash key.'
+examples:
+    - description: 'Provide a paragraph type  and module name'
+      execution: |
+        drupal config:export:paragraph:type page \
+          --module="demo"
+    - description: 'If you want export paragraph type provide the optional config'
+      execution: |
+        drupal config:export:paragraph:type page \
+          --module="demo" \
+          --optional-config 
+


### PR DESCRIPTION
Added translation file for Paragraph type export to export Paragraph type's fields with following command:

drupal config:export:paragraph:type

(Functionality code in separate pull request on drupal-console repository) 