### PR TITLE
[generate:plugin:queue] Translation queueworker plugin generator.

### DIFF
--- a/translations/generate.plugin.queue.yml
+++ b/translations/generate.plugin.queue.yml
@@ -15,7 +15,7 @@ questions:
 examples:
   - description: 'Generate a queue worker plugin specifying the module name, the class and its plugin id'
     execution: |
-      drupal generate:plugin:migrate:source  \
+      drupal generate:plugin:queue  \
         --module="modulename"  \
         --class="PluginClassName"  \
         --plugin-id="plugin_class_name"  \

--- a/translations/generate.plugin.queue.yml
+++ b/translations/generate.plugin.queue.yml
@@ -8,9 +8,9 @@ options:
   cron-time: 'Cron time'
   label: 'Queue description'
 questions:
-  queue-file: 'Enter the QueueWorker file name'
-  queue-id: 'Enter the QueueWorker id'
-  cront-time: 'Enter the cron time to execute you queue'
+  class: 'Enter the QueueWorker class name'
+  plugin-id: 'Enter the Plugin QueueWorker id'
+  cron-time: 'Enter the cron time to execute you queue'
   label: 'Enter the Queue description'
 examples:
   - description: 'Generate a queue worker plugin specifying the module name, the class and its plugin id'

--- a/translations/generate.plugin.queue.yml
+++ b/translations/generate.plugin.queue.yml
@@ -1,0 +1,25 @@
+description: 'Drupal Console Queueworker generator.'
+help: 'The <info>generate:plugin:queue</info> command helps you generate a new queue worker plugin.'
+welcome: 'Welcome to the Drupal Queue Worker Plugin generator'
+options:
+  module: 'The module name'
+  class: 'QueueWorker file name'
+  plugin-id: 'Plugin QueueWorker id'
+  cron-time: 'Cron time'
+  label: 'Queue description'
+questions:
+  queue-file: 'Enter the QueueWorker file name'
+  queue-id: 'Enter the QueueWorker id'
+  cront-time: 'Enter the cron time to execute you queue'
+  label: 'Enter the Queue description'
+examples:
+  - description: 'Generate a queue worker plugin specifying the module name, the class and its plugin id'
+    execution: |
+      drupal generate:plugin:migrate:source  \
+        --module="modulename"  \
+        --class="PluginClassName"  \
+        --plugin-id="plugin_class_name"  \
+        --cron-time="30"  \
+        --label="Example QueueWorker"
+messages:
+    success: 'The Queueworker was generated successfully.'


### PR DESCRIPTION
### Problem/Motivation
Translation Queueworker generator.

### How to reproduce
Generate a new Queueworker in a existing module using `drupal generate:plugin:queue`.

### Details to include:
Drupal version - 8.6.1
drupal/console 1.8.0 The Drupal CLI. A tool to generate boilerplate code, interact with and debug Drupal.
drupal/console-core 1.8.0 Drupal Console Core
drupal/console-en 1.8.0 Drupal Console English Language
drupal/console-extend-plugin 0.9.2 Drupal Console Extend Plugin
Console Launcher version - 1.8.0

Related issue: https://github.com/hechoendrupal/drupal-console/pull/3950