### PR TITLE
Fix typo in entity delete command description

### DIFF
--- a/translations/entity.delete.yml
+++ b/translations/entity.delete.yml
@@ -1,4 +1,4 @@
-description: 'Delete an specific entity'
+description: 'Delete a specific entity'
 help: 'The <info>entity:delete</info> command helps you delete entities.'
 arguments:
   entity-definition-id: 'Entity definition id'


### PR DESCRIPTION
Hi there. Just noticed a typo in the entity delete command. Here is a PR that fixes this.

Thanks for console!